### PR TITLE
bug: inf loop when souce file is the same as dest file and it's the only file in the folder

### DIFF
--- a/grub_img_swpr.py
+++ b/grub_img_swpr.py
@@ -54,6 +54,9 @@ def moveImageFile():
 
     i = random.randrange(len(files))
     while imgDir + files[i] == backgroundImgFilePath:
+        if len(files) = 1:
+            print('The imgFile and backgroundImgFilePath are the same and are also the only file in the destination folder. Exiting.')
+            return
         print('Files are the same. Generating new random.')
         i = random.randrange(len(files))
     


### PR DESCRIPTION
bugfix: Update to handle the scenario where the imgDir + files[i] file is the same as the backgroundImgFilePath and is also the only file in the directory.